### PR TITLE
Add persistent default path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.17]
+### Added
+- Remember last download location for quicker subsequent downloads.
+
 ## [0.0.16]
 ### Added
 - Enhanced SSH Key Setup Instructions.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Allows for fast and efficient downloads of files and directories from a **VSCode
 - **Rsync-Based Transfers**: Utilizes `rsync` for optimized and reliable synchronization between remote servers and your local machine.
 - **Automatic Rsync Installation and Version Check**: Automatically checks if `rsync` is installed and up-to-date on your local machine, providing guidance for installation or updates.
 - **Passwordless SSH Authentication Detection**: Detects if passwordless SSH authentication is not set up and provides clear instructions for configuration.
+- **Remembers Last Download Location**: Automatically suggests the previously used download directory for convenience.
 
 ## Benefits
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "compress-download-extension",
   "displayName": "Remote - SSH: Fast Download",
   "description": "A simple extension to more quickly download files from a remote server in VSCode.",
-  "version": "0.0.16",
+  "version": "0.0.17",
   "publisher": "samueletorregrossa",
   "icon": "icon.png",
   "engines": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -261,21 +261,29 @@ SSH Key Setup Instructions
 
       // 5) At this point, we have verified rsync & passwordless SSH
       //    Prompt for a local download destination
+      const savedLastLocation = context.globalState.get<string>(
+        "lastDownloadLocation"
+      );
+
       const defaultDownloadLocation = vscode.workspace
         .getConfiguration("fastDownload")
         .get<string>("defaultDownloadLocation");
 
-      const destinationPath =
-        defaultDownloadLocation ||
-        (await vscode.window.showInputBox({
+      let destinationPath = defaultDownloadLocation;
+      if (!destinationPath) {
+        destinationPath = await vscode.window.showInputBox({
           prompt: "Enter the local destination path",
-          value: path.join(os.homedir(), "Downloads"),
-        }));
+          value: savedLastLocation || path.join(os.homedir(), "Downloads"),
+        });
+      }
 
       if (!destinationPath) {
         vscode.window.showErrorMessage("No destination path provided.");
         return;
       }
+
+      // Remember last chosen download location
+      context.globalState.update("lastDownloadLocation", destinationPath);
 
       // 6) Construct the rsync command
       const remoteFiles = uriList.map((uri) => {


### PR DESCRIPTION
## Summary
- remember the last chosen download directory
- show previously used directory in the prompt
- document the new behavior in the README and changelog
- bump version to 0.0.17

## Testing
- `npm run compile` *(fails: Cannot find module 'vscode' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6842b4780ed4832791cf37e600a34192